### PR TITLE
Add bought item summary

### DIFF
--- a/src/components/PageComponents/OrderSummaryModal.tsx
+++ b/src/components/PageComponents/OrderSummaryModal.tsx
@@ -8,22 +8,24 @@ type Props = {
 }
 const OrderSummaryModal = (props: Props) => {
   const { order } = props
-  const wishList = order.procurementWishes.map((o) => o.items.map((item, id) => item.name))
-  const orderList = order.orders.filter((o) => !o.canceled).map((o) => o.items.map((mpng) => mpng.item.name))
-  const flatWishList = wishList.reduce((acc, val) => acc.concat(val), [])
+  const procurementList = order.procurementWishes.map((o) => o.items.map((item, id) => item.name))
+  const orderList = order.orders
+    .filter((o) => !o.canceled)
+    .map((o) => o.items.map((items) => items.item.name))
+
+  const flatProcurementList = procurementList.reduce((acc, val) => acc.concat(val), [])
   const flatOrderList = orderList.reduce((acc, val) => acc.concat(val), [])
 
-  const wishOccurrences = flatWishList.reduce((acc:{[index:string]: number}, value) => {
+  const procurementOccurrences = flatProcurementList.reduce((acc: { [index: string]: number }, value) => {
+    acc[value] = (acc[value] || 0) + 1
+    return acc
+  }, {})
+  const orderOccurrences = flatOrderList.reduce((acc: { [index: string]: number }, value) => {
     acc[value] = (acc[value] || 0) + 1
     return acc
   }, {})
 
-  const orderOccurrences = flatOrderList.reduce((acc:{[index:string]: number}, value) => {
-    acc[value] = (acc[value] || 0) + 1
-    return acc
-  }, {})
-
-  const totalWishItems = Object.entries(wishOccurrences).reduce((acc, val) => acc + val[1] , 0)
+  const totalProcurementItems = Object.entries(procurementOccurrences).reduce((acc, val) => acc + val[1], 0)
 
   return (
     <Modal
@@ -33,13 +35,21 @@ const OrderSummaryModal = (props: Props) => {
         props.setOpen(false)
       }}
     >
-        <p className="font-bold text-lg my-2">Bestellte Items</p>
-        {Object.entries(wishOccurrences).map(([item, count]) => (<p key={item}>{item}: <span className="font-bold">{count}</span></p>))}
-        <p className="font-light mt-2">Insgesamt gewünscht: {totalWishItems}</p>
-      
-        <p className="font-bold text-lg my-2">Gekaufte Items</p>
-        {Object.entries(orderOccurrences).map(([item, count]) => (<p key={item}>{item}: <span className="font-bold">{count}</span></p>))}
+      <p className="my-2 text-lg font-bold">Angefragte Items</p>
+      {Object.entries(procurementOccurrences).map(([item, count]) => (
+        <p key={item}>
+          {item}: <span className="font-bold">{count}</span>
+        </p>
+      ))}
+      <p className="font-extralight">Insgesamt: {totalProcurementItems}</p>
 
+      <p className="mb-2 mt-7 text-lg font-bold">Gekaufte Items</p>
+      {Object.entries(orderOccurrences).map(([item, count]) => (
+        <p key={item}>
+          {item}: <span className="font-bold">{count}</span>
+        </p>
+      ))}
+      <p className="font-extralight">Insgesamt: {totalProcurementItems}</p>
     </Modal>
   )
 }

--- a/src/components/PageComponents/OrderSummaryModal.tsx
+++ b/src/components/PageComponents/OrderSummaryModal.tsx
@@ -8,15 +8,22 @@ type Props = {
 }
 const OrderSummaryModal = (props: Props) => {
   const { order } = props
-  const itemList = order.procurementWishes.map((o) => o.items.map((item, id) => item.name))
-  const flatItemList = itemList.reduce((acc, val) => acc.concat(val), [])
+  const wishList = order.procurementWishes.map((o) => o.items.map((item, id) => item.name))
+  const orderList = order.orders.filter((o) => !o.canceled).map((o) => o.items.map((mpng) => mpng.item.name))
+  const flatWishList = wishList.reduce((acc, val) => acc.concat(val), [])
+  const flatOrderList = orderList.reduce((acc, val) => acc.concat(val), [])
 
-  const occurrences = flatItemList.reduce((acc:{[index:string]: number}, value) => {
+  const wishOccurrences = flatWishList.reduce((acc:{[index:string]: number}, value) => {
     acc[value] = (acc[value] || 0) + 1
     return acc
   }, {})
 
-  const totalItems = Object.entries(occurrences).reduce((acc, val) => acc + val[1] , 0)
+  const orderOccurrences = flatOrderList.reduce((acc:{[index:string]: number}, value) => {
+    acc[value] = (acc[value] || 0) + 1
+    return acc
+  }, {})
+
+  const totalWishItems = Object.entries(wishOccurrences).reduce((acc, val) => acc + val[1] , 0)
 
   return (
     <Modal
@@ -27,8 +34,12 @@ const OrderSummaryModal = (props: Props) => {
       }}
     >
         <p className="font-bold text-lg my-2">Bestellte Items</p>
-        {Object.entries(occurrences).map(([item, count]) => (<p key={item}>{item}: <span className="font-bold">{count}</span></p>))}
-        <p className="font-light mt-2">Insgesammt: {totalItems}</p>
+        {Object.entries(wishOccurrences).map(([item, count]) => (<p key={item}>{item}: <span className="font-bold">{count}</span></p>))}
+        <p className="font-light mt-2">Insgesamt gewünscht: {totalWishItems}</p>
+      
+        <p className="font-bold text-lg my-2">Gekaufte Items</p>
+        {Object.entries(orderOccurrences).map(([item, count]) => (<p key={item}>{item}: <span className="font-bold">{count}</span></p>))}
+
     </Modal>
   )
 }


### PR DESCRIPTION
We had the problem that we missed the bought items in the group orders, therefore I added them to the order summary.

I have no idea what I am doing, and I don't know TypeScript, and don't wanna set this whole thing up, therefore this code is untested please test this before you merge.

I also didn't add the ordered items to the total (I added some text to clarify that)  because we only need the total of the wished items, without the ordered ones. If you want I could also add the total Items below, as that would be more generic and less tailored to just our specific needs, idk…