### PR TITLE
Move closed group orders below open ones

### DIFF
--- a/src/pages/grouporders/index.tsx
+++ b/src/pages/grouporders/index.tsx
@@ -95,12 +95,6 @@ const GroupOrders: NextPage = () => {
     <>
       <CenteredPage>
         <div className="container">
-          {groupOrdersInProgress.data?.map((group) => (
-            <GroupOrderDetailView key={group.id} group={group} />
-          ))}
-        </div>
-
-        <div className="container">
           {groupOrderRequest.data?.map((groupOrder) => (
             <div key={groupOrder.id} className="card mb-5 max-w-5xl bg-base-200 p-3">
               <div className="flex flex-col justify-start gap-1 p-1">
@@ -182,6 +176,12 @@ const GroupOrders: NextPage = () => {
                 </div>
               </div>
             </div>
+          ))}
+        </div>
+        
+        <div className="container">
+          {groupOrdersInProgress.data?.map((group) => (
+            <GroupOrderDetailView key={group.id} group={group} />
           ))}
         </div>
 


### PR DESCRIPTION
Else everyone has to scroll… It's only a little rearrangement of the HTML so should be fine, but still check if this makes sense, I didn't test this whatsoever…